### PR TITLE
MINOR; Update merge script to work against Python3 

### DIFF
--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -183,10 +183,6 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
             committer_name, committer_email)
         merge_message_flags += ["-m", message]
 
-    # The string "Closes #%s" string is required for GitHub to correctly close the PR
-    close_line = "Closes #%s from %s" % (pr_num, pr_repo_desc)
-    merge_message_flags += ["-m", close_line]
-
     run_cmd(['git', 'commit', '--author="%s"' % primary_author] + merge_message_flags)
 
     continue_maybe("Merge complete (local ref %s). Push to %s?" % (


### PR DESCRIPTION
Made the following changes so that it works in Python3:

1. Use `print()` instead of `print`
2. Use urllib instead of urllib2
3. Decode all of the cmd outputs from bynary to string using UTF-8
4. Use `input` instead of `raw_input`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
